### PR TITLE
Implement design

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteMetadata: {
-    title: `Gatsby Default Starter`,
-    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
-    author: `@gatsbyjs`,
+    title: `Astorians' Voting Guide 2020`,
+    description: `Register to vote!`,
+    author: `astoria.digital`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -18,11 +18,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
+        name: `astorians-voting-guide-2020`,
+        short_name: `voting-guide`,
         start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
+        background_color: `#6D3C7E`,
+        theme_color: `#6D3C7E`,
         display: `minimal-ui`,
         icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },

--- a/src/components/Mapbox.js
+++ b/src/components/Mapbox.js
@@ -2,11 +2,7 @@ import React, { useEffect, useRef } from "react"
 import mapboxgl from "mapbox-gl"
 import "mapbox-gl/dist/mapbox-gl.css"
 
-const styles = {
-  width: "50vw",
-  height: "calc(100vh - 80px)",
-  position: "absolute",
-}
+import "./mapbox.css"
 
 const Mapbox = () => {
   const mapContainer = useRef(null)
@@ -37,9 +33,7 @@ const Mapbox = () => {
     })
   }, [])
 
-  return (
-    <div ref={el => (mapContainer.current = el)} id="mapbox" style={styles} />
-  )
+  return <div ref={el => (mapContainer.current = el)} id="mapbox" />
 }
 
 export default Mapbox

--- a/src/components/ballot-info.css
+++ b/src/components/ballot-info.css
@@ -1,0 +1,5 @@
+.ballot-info__body {
+  background-color: #c4c4c4;
+  max-width: 100%;
+  height: 640px;
+}

--- a/src/components/ballot-info.js
+++ b/src/components/ballot-info.js
@@ -1,0 +1,21 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "./ballot-info.css"
+
+const BallotInfo = ({ headline }) => {
+  return (
+    <div className="ballot-info">
+      <h2 className="ballot-info__headline">{headline}</h2>
+      <div className="ballot-info__body"></div>
+    </div>
+  )
+}
+
+BallotInfo.propTypes = {
+  headline: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  submit: PropTypes.string.isRequired,
+}
+
+export default BallotInfo

--- a/src/components/ctas.css
+++ b/src/components/ctas.css
@@ -1,0 +1,21 @@
+.ctas {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+}
+
+.cta {
+  display: inline-block;
+  padding: 1em;
+  font-size: 1.34rem;
+  background-color: var(--primary-color);
+  color: #fff;
+  text-decoration: none;
+  margin-top: 0.5em;
+  max-width: 15em;
+  text-align: center;
+}
+
+.cta--highlight {
+  background-color: var(--highlight-color);
+}

--- a/src/components/ctas.js
+++ b/src/components/ctas.js
@@ -1,0 +1,22 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "./ctas.css"
+
+const Ctas = ({ items }) => {
+  return (
+    <div className="ctas">
+      {items.map(cta => (
+        <a href={cta.href} key={cta.text} className={`cta ${cta.classes}`}>
+          {cta.text}
+        </a>
+      ))}
+    </div>
+  )
+}
+
+Ctas.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+export default Ctas

--- a/src/components/dates-deadlines.css
+++ b/src/components/dates-deadlines.css
@@ -1,0 +1,18 @@
+.dates-deadlines {
+  border: 1px solid #000;
+}
+
+.dates-deadlines__headline {
+  padding: 0.5em;
+  border-bottom: 1px solid #000;
+  background-color: var(--danger-color);
+  color: #fff;
+}
+
+.dates-deadlines__list {
+  list-style-type: none;
+}
+
+.dates-deadlines__text {
+  text-transform: uppercase;
+}

--- a/src/components/dates-deadlines.js
+++ b/src/components/dates-deadlines.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types"
+import React from "react"
+
+import "./dates-deadlines.css"
+
+const DatesDeadlines = ({ items, headline }) => (
+  <section className="dates-deadlines">
+    <h2 className="dates-deadlines__headline">{headline}</h2>
+    <ul className="dates-deadlines__list">
+      {items.map(item => (
+        <li className="dates-deadlines__item">
+          <time dateTime={item.datetime}>{item.date}</time> —{" "}
+          <span className="dates-deadlines__text">{item.text}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)
+
+DatesDeadlines.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  headline: PropTypes.string.isRequired,
+}
+
+export default DatesDeadlines

--- a/src/components/grid-box.css
+++ b/src/components/grid-box.css
@@ -1,0 +1,30 @@
+@media screen and (min-width: 700px) {
+
+  .grid-box {
+    margin-top: 2em;
+    display: grid;
+    grid-gap: 2em;
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .grid-box .polling {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .grid-box .mapboxgl-map {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .grid-box .ballot-info {
+    grid-column: 2;
+    grid-row: 1 / 3;
+  }
+
+  .grid-box .ctas {
+    grid-column: 1 / -1;
+    grid-row: 3;
+  }
+
+}

--- a/src/components/grid-box.js
+++ b/src/components/grid-box.js
@@ -1,0 +1,14 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "./grid-box.css"
+
+const GridBox = ({ children }) => {
+  return <section className="grid-box">{children}</section>
+}
+
+GridBox.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default GridBox

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -1,0 +1,44 @@
+.site-header {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  background-color: var(--primary-color);
+  color: #fff;
+  border-bottom: 3px solid #000;
+  height: 9.5rem;
+}
+
+.site-headline {
+  margin: 0 0 0 0.5em;
+}
+
+.vote-icon {
+  display: none;
+}
+
+@media screen and (min-width: 430px) {
+  .vote-icon {
+    display: block;
+    max-width: 96px;
+    margin-left: 1em;
+  }
+}
+
+.language-selector {
+  margin-left: auto;
+  height: 100%;
+}
+
+.language-selector__button {
+  height: 100%;
+  border: none;
+  padding-left: 2em;
+  padding-right: 2em;
+  border-left: 3px solid #000;
+  background-color: #fff;
+  text-transform: uppercase;
+}
+
+.language-selector__menu[aria-expanded="false"] {
+  display: none;
+}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,32 +1,47 @@
-import { Link } from "gatsby"
 import PropTypes from "prop-types"
 import React from "react"
 
+import "./header.css"
+
 const Header = ({ siteTitle }) => (
-  <header
-    style={{
-      background: `rebeccapurple`,
-      marginBottom: `1.45rem`,
-    }}
-  >
-    <div
-      style={{
-        margin: `0 auto`,
-        maxWidth: 960,
-        padding: `1.45rem 1.0875rem`,
-      }}
+  <header className="site-header">
+    <svg
+      className="vote-icon"
+      viewBox="0 0 96 96"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <h1 style={{ margin: 0 }}>
-        <Link
-          to="/"
-          style={{
-            color: `white`,
-            textDecoration: `none`,
-          }}
-        >
-          {siteTitle}
-        </Link>
-      </h1>
+      <path d="M6.02 71.93v3.185h6.021V71.93h-6.02zm6.021 3.185v2.835h6.032v-2.835h-6.032zm6.032 2.835v3.186h6.02V77.95h-6.02zm6.02 3.186v2.834h2.835v-2.834h-2.835zm2.835 2.834v3.198h6.02V83.97h-6.02zm6.02 3.198v2.834h6.021v-2.834H32.95zm6.021 2.834v2.835h6.032v-2.835H38.97zM12.052 47.836v3.186h6.01v-3.186h-6.01zm6.01 3.186v2.834h6.031v-2.834h-6.031zm6.031 2.834v3.186h6.021v-3.186h-6.02zm6.021 3.186v2.835h6.02v-2.835h-6.019zm6.02 2.835v3.197h6.032v-3.209h-6.02l-.011.012zm6.032 3.197v2.835h5.67v-2.835h-5.67zm50.67-20.907V45h-5.668v2.835h-6.032v3.186h-6.02v2.834h-6.021v3.186h-6.032v2.835h-6.01v3.197h-6.031v2.835h-3.186v26.928H45v3.174h8.855v-3.174h6.02v-2.835h6.033v-2.834h6.009V83.97h3.197v-2.834h6.02V77.95h6.033v-2.835h5.669V71.93h3.174V42.166h-3.174zm-90.001 0v29.75H6.02v-24.07h6.02v-2.835h-6.01v-2.834H2.836v-.011z" />
+      <path d="M69.094 30.114v2.835h6.02v-2.835h-6.02zm6.02 2.835v3.186h6.021V32.96h-6.02v-.011zm6.021 3.186v2.834h6.032v-2.834h-6.032zm6.032 2.834v3.197h5.67v-3.185h-5.67v-.012zM30.114 26.93v3.185h6.02v-3.186H30.114zm0 3.185h-6.02v2.835h6.02v-2.835zm-6.02 2.835h-6.021v3.186h6.02v-3.186zm-6.021 3.186H12.04v2.834h6.032v-2.834zm-6.032 2.834H6.03v3.197h6.01V38.97zm45.001-20.896v2.834h-3.186v3.186H51.02v2.835h-3.186v-2.835h-2.834v6.021h2.834v2.835h3.186v-2.835h2.835v-3.186h3.186v-2.835h2.834v-6.02h-2.834zM47.835 2.835V6.02h9.207V2.835h-9.207z" />
+      <path d="M38.98 0v24.093h-2.834v2.835h2.835v6.02h-2.835v3.187h-3.197v2.834h3.186v3.197h6.032v2.835h5.669v2.835h6.02v3.186h6.02v2.834h6.033v-2.834h3.174v-3.186H65.91V30.114h3.174v-3.186H65.91V6.021H57.03v2.834h6.032v38.992H57.03v-2.835h-6.01v-2.834h-6.02v-3.186h-2.834V2.835h5.669V0h-8.867.012z" />
+    </svg>
+    <h1 className="site-headline">Astorians' Voting Guide 2020</h1>
+    <div className="language-selector">
+      <button
+        id="language-button"
+        className="language-selector__button"
+        aria-haspopup="true"
+        aria-owns="language-selector"
+        aria-label="Current language is English. Choose your preferred language."
+      >
+        English
+      </button>
+      <ul
+        id="language-menu"
+        role="menu"
+        aria-expanded="false"
+        className="language-selector__menu"
+      >
+        <li role="menuitem" lang="en">
+          <a href="#" title="English">
+            English
+          </a>
+        </li>
+        <li role="menuitem" lang="es">
+          <a href="#" title="Spanish">
+            Español
+          </a>
+        </li>
+      </ul>
     </div>
   </header>
 )

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,3 +1,10 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Fjalla+One&display=swap");
+:root {
+  --primary-color: #6D3C7E;
+  --highlight-color: #FF7A00;
+  --danger-color: #FF0000;
+  --secondary-color: #FFDA00;
+}
 html {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -10,7 +17,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: hsla(0, 0%, 0%, 0.8);
-  font-family: georgia, serif;
+  font-family: "DM Mono", monospace;
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;
@@ -81,8 +88,7 @@ h1 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 2.25rem;
@@ -122,6 +128,9 @@ img {
 }
 svg:not(:root) {
   overflow: hidden;
+}
+svg path {
+  fill: currentColor;
 }
 code,
 kbd,
@@ -193,6 +202,10 @@ button::-moz-focus-inner {
 button:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
+input[type="submit"]:hover,
+button:hover {
+  cursor: pointer;
+}
 fieldset {
   border: 1px solid silver;
   padding: 0.35em 0.625em 0.75em;
@@ -260,8 +273,7 @@ h2 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1.62671rem;
@@ -277,8 +289,23 @@ h3 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
+  font-weight: bold;
+  text-rendering: optimizeLegibility;
+  font-size: 1.62671rem;
+  line-height: 1.1;
+}
+h3 {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-bottom: 1.45rem;
+  color: inherit;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1.38316rem;
@@ -294,8 +321,7 @@ h4 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1rem;
@@ -311,8 +337,7 @@ h5 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 0.85028rem;
@@ -328,8 +353,7 @@ h6 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: "Fjalla One", sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 0.78405rem;
@@ -589,6 +613,21 @@ pre code:after,
 pre tt:before,
 pre tt:after {
   content: "";
+}
+main {
+  padding: 2em;
+}
+footer {
+  border-top: 3px solid #000;
+  background-color: var(--secondary-color);
+  height: 9em;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: center;
+}
+footer a {
+  color: #000;
 }
 @media only screen and (max-width: 480px) {
   html {

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -26,20 +26,13 @@ const Layout = ({ children }) => {
   return (
     <>
       <Header siteTitle={data.site.siteMetadata.title} />
-      <div
-        style={{
-          margin: `0 auto`,
-          maxWidth: 960,
-          padding: `0 1.0875rem 1.45rem`,
-        }}
-      >
-        <main>{children}</main>
-        <footer>
-          © {new Date().getFullYear()}, Built with
-          {` `}
-          <a href="https://www.gatsbyjs.org">Gatsby</a>
-        </footer>
-      </div>
+      <main>{children}</main>
+      <footer>
+        <small>
+          © {new Date().getFullYear()}{" "}
+          <a href="https://astoria.digital">Astoria Digital</a>
+        </small>
+      </footer>
     </>
   )
 }

--- a/src/components/mapbox.css
+++ b/src/components/mapbox.css
@@ -1,0 +1,5 @@
+.mapboxgl-map {
+  width: 100%;
+  height: 50vh;
+  margin-bottom: 2em;
+}

--- a/src/components/polling.css
+++ b/src/components/polling.css
@@ -1,0 +1,24 @@
+.polling__headline {
+  font-weight: bold;
+  font-family: "Fjalla One", sans-serif;
+  text-rendering: optimizeLegibility;
+  font-size: 1.62671rem;
+  line-height: 1.1;
+  display: block;
+  margin-bottom: 1.45rem;
+}
+
+.polling__search {
+  padding: 1em;
+  border: 1px solid #000;
+  width: calc(100% - 6em);
+  max-width: 690px;
+}
+
+.polling__submit {
+  border: 1px solid #000;
+  border-left: none;
+  padding: 1em;
+  color: #fff;
+  background-color: var(--primary-color);
+}

--- a/src/components/polling.js
+++ b/src/components/polling.js
@@ -1,0 +1,29 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "./polling.css"
+
+const Polling = ({ headline, placeholder, submit }) => {
+  return (
+    <form className="polling" action="#">
+      <label className="polling__headline" htmlFor="polling-search">
+        {headline}
+      </label>
+      <input
+        type="search"
+        id="polling-search"
+        className="polling__search"
+        placeholder={placeholder}
+      />
+      <input type="submit" className="polling__submit" value={submit} />
+    </form>
+  )
+}
+
+Polling.propTypes = {
+  headline: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  submit: PropTypes.string.isRequired,
+}
+
+export default Polling

--- a/src/components/tips.css
+++ b/src/components/tips.css
@@ -1,0 +1,14 @@
+.tips {
+  margin-top: 2em;
+  border: 1px solid #000;
+}
+
+.tips__headline {
+  padding: 0.5em;
+  border-bottom: 1px solid #000;
+}
+
+.tips__list {
+  margin-left: 2rem;
+  list-style-type: " - ";
+}

--- a/src/components/tips.js
+++ b/src/components/tips.js
@@ -1,0 +1,24 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import "./tips.css"
+
+const Tips = ({ headline, items }) => {
+  return (
+    <section className="tips">
+      <h2 className="tips__headline">{headline}</h2>
+      <ul className="tips__list">
+        {items.map(tip => (
+          <li className="tips__item">{tip}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+Tips.propTypes = {
+  headline: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+export default Tips

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,17 +1,34 @@
 import React from "react"
-import { Link } from "gatsby"
 
-import Mapbox from "../components/Mapbox"
+import BallotInfo from "../components/ballot-info"
+import Ctas from "../components/ctas"
+import DatesDeadlines from "../components/dates-deadlines"
+import GridBox from "../components/grid-box"
 import Layout from "../components/layout"
+import Mapbox from "../components/Mapbox"
+import Polling from "../components/polling"
 import SEO from "../components/seo"
+import Tips from "../components/tips"
 import strings from "../util/strings"
 
 const IndexPage = () => (
   <Layout>
     <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>{strings.test}</p>
-    <Mapbox />
+    <DatesDeadlines
+      items={strings.datesDeadlines.items}
+      headline={strings.datesDeadlines.headline}
+    />
+    <GridBox>
+      <Polling
+        placeholder={strings.polling.placeholder}
+        headline={strings.polling.headline}
+        submit={strings.polling.submit}
+      />
+      <Mapbox />
+      <BallotInfo headline={strings.ballotInfo.headline} />
+      <Ctas items={strings.ctas} />
+    </GridBox>
+    <Tips headline={strings.tips.headline} items={strings.tips.items} />
   </Layout>
 )
 

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -2,10 +2,127 @@ import LocalizedStrings from "react-localization"
 
 export const strings = new LocalizedStrings({
   en: {
-    test: "Register to vote!",
+    datesDeadlines: {
+      headline: "Important Dates and Deadlines",
+      items: [
+        {
+          text: "Last day of applying for absentee ballot by mail",
+          date: "Oct 09 (Fri)",
+          datetime: "2020-10-09",
+        },
+        {
+          text: "Early voting begins",
+          date: "Oct 24 (Sat)",
+          datetime: "2020-10-24",
+        },
+        {
+          text: "Early voting ends",
+          date: "Nov 01 (Sun)",
+          datetime: "2020-11-01",
+        },
+        {
+          text: "Election day, vote in person",
+          date: "Nov 03 (Tue)",
+          datetime: "2020-11-03",
+        },
+      ],
+    },
+    polling: {
+      headline: "Your Polling Stations",
+      placeholder: "Your address",
+      submit: "Search",
+    },
+    ballotInfo: {
+      headline: "Ballot info",
+    },
+    ctas: [
+      {
+        text: "Update your voter registration",
+        href: "#",
+        classes: "",
+      },
+      {
+        text: "Apply for Absentee Ballot",
+        href: "#",
+        classes: "",
+      },
+      {
+        text: "Look for a Ride to Your Polling Station",
+        href: "#",
+        classes: "cta--highlight",
+      },
+    ],
+    tips: {
+      headline: "Essential Tips",
+      items: [
+        "One Lorem ibsum dolar mat",
+        "Two Lorem ibsum dolar mat",
+        "Three Lorem ibsum dolar mat",
+        "Four Lorem ibsum dolar mat",
+      ],
+    },
   },
   es: {
-    test: "Registrarse para votar",
+    datesDeadlines: {
+      headline: "Fechas y plazos importantes",
+      items: [
+        {
+          text:
+            "Último día para solicitar una boleta de voto ausente por correo",
+          date: "Oct 09 (Fri)",
+          datetime: "2020-10-09",
+        },
+        {
+          text: "Comienza la votación anticipada",
+          date: "Oct 24 (Sat)",
+          datetime: "2020-10-24",
+        },
+        {
+          text: "Finaliza la votación anticipada",
+          date: "Nov 01 (Sun)",
+          datetime: "2020-11-01",
+        },
+        {
+          text: "El día de las elecciones, votar en persona",
+          date: "Nov 03 (Tue)",
+          datetime: "2020-11-03",
+        },
+      ],
+    },
+    polling: {
+      headline: "Tus mesas de votación",
+    },
+    ballotInfo: {
+      headline: "Información de la boleta",
+      placeholder: "Su dirección",
+      submit: "Buscar",
+    },
+    ctas: [
+      {
+        text: "Actualice su registro de votante",
+        href: "#",
+        classes: "",
+      },
+      {
+        text: "Solicite una boleta de voto ausente",
+        href: "#",
+        classes: "",
+      },
+      {
+        text: "Busque transporte a su colegio electoral",
+        href: "#",
+        classes: "cta--highlight",
+      },
+    ],
+    tips: {
+      headline: "Essential Tips",
+      items: [
+        "One Lorem ibsum dolar mat",
+        "Two Lorem ibsum dolar mat",
+        "Three Lorem ibsum dolar mat",
+        "Four Lorem ibsum dolar mat",
+      ],
+    },
   },
 })
 


### PR DESCRIPTION
Add responsive styles and semantic, accessible markup to implement
Alex's design.

Add translation strings for most text. Only English and Spanish (using
Google translate) for now, but extends the current pattern and should be
extensible.

Language drop down is marked up with accessible markup, but no JS
behaviors are added yet.

Same with the search box. Markup and styles are present, but no
behaviors.

Essential tips data was left as lorem ibsum for now, matching current
mock up.

Change meta data (site title, etc) to match the site.

Open to feedback.