### PR TITLE
Add hover effect to all buttons

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -202,9 +202,11 @@ button::-moz-focus-inner {
 button:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
+a:link:hover,
 input[type="submit"]:hover,
 button:hover {
   cursor: pointer;
+  filter: brightness(120%);
 }
 fieldset {
   border: 1px solid silver;


### PR DESCRIPTION
Apply the `brightness` filter to increase the color lightness by 20% for
all buttons. This allows setting the hover effect once, no matter what
the button color is, and the background will get lighter on hover.