### PR TITLE
Fix headline whitespace bug

### DIFF
--- a/src/components/dates-deadlines.css
+++ b/src/components/dates-deadlines.css
@@ -11,6 +11,7 @@
 
 .dates-deadlines__list {
   list-style-type: none;
+  margin-right: 0.5em;
 }
 
 .dates-deadlines__text {

--- a/src/components/grid-box.css
+++ b/src/components/grid-box.css
@@ -1,7 +1,10 @@
+.grid-box {
+  margin-top: 2em;
+}
+
 @media screen and (min-width: 700px) {
 
   .grid-box {
-    margin-top: 2em;
     display: grid;
     grid-gap: 2em;
     grid-template-columns: 2fr 1fr;


### PR DESCRIPTION
The margin that spaces out the map and related components from the
important dates component I mistakenly put inside a media query. Move it
outside to effect all screen sizes.

Also, add a little margin to the right edge of important dates list, so
that as the content wraps the text never ends up flush with the right
edge line.