### PR TITLE
Move important dates to the sidebar

### DIFF
--- a/frontend/src/components/ballot-info.css
+++ b/frontend/src/components/ballot-info.css
@@ -1,5 +1,9 @@
+.ballot-info {
+  margin-top: 2em;
+}
+
 .ballot-info__body {
   background-color: #c4c4c4;
   max-width: 100%;
-  height: 640px;
+  height: 220px;
 }

--- a/frontend/src/components/dates-deadlines.css
+++ b/frontend/src/components/dates-deadlines.css
@@ -5,8 +5,6 @@
 .dates-deadlines__headline {
   padding: 0.5em;
   border-bottom: 1px solid #000;
-  background-color: var(--danger-color);
-  color: #fff;
 }
 
 .dates-deadlines__list {

--- a/frontend/src/components/grid-box.css
+++ b/frontend/src/components/grid-box.css
@@ -20,7 +20,7 @@
     grid-row: 2;
   }
 
-  .grid-box .ballot-info {
+  .grid-sidebar {
     grid-column: 2;
     grid-row: 1 / 3;
   }

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -16,10 +16,6 @@ const IndexPage = () => {
   return (
     <Layout>
       <SEO title="Home" />
-      <DatesDeadlines
-        items={strings.datesDeadlines.items}
-        headline={strings.datesDeadlines.headline}
-      />
       <GridBox>
         <Polling
           items={strings.polling.items}
@@ -28,7 +24,13 @@ const IndexPage = () => {
           setVoterData={setVoterData}
         />
         <Mapbox voterData={voterData} />
-        <BallotInfo headline={strings.ballotInfo.headline} />
+        <aside className="grid-sidebar">
+          <DatesDeadlines
+            items={strings.datesDeadlines.items}
+            headline={strings.datesDeadlines.headline}
+          />
+          <BallotInfo headline={strings.ballotInfo.headline} />
+        </aside>
         <Ctas items={strings.ctas} />
       </GridBox>
       <Tips headline={strings.tips.headline} items={strings.tips.items} />


### PR DESCRIPTION
De-emphasize the important dates component by moving it to the right
sidebar. This is to put the main focus on the search and map
functionality, which is the major focus of the application.

Also remove the red background color to further de-emphasise the unit.
Red really draws focus, so remove it to give it the proper emphasis.