### PR TITLE
Add voting phone numbers

### DIFF
--- a/frontend/src/components/dates-deadlines.css
+++ b/frontend/src/components/dates-deadlines.css
@@ -3,6 +3,7 @@
 }
 
 .dates-deadlines__headline {
+  margin-top: 0;
   padding: 0.5em;
   border-bottom: 1px solid #000;
   background-color: var(--highlight-color);

--- a/frontend/src/components/layout.css
+++ b/frontend/src/components/layout.css
@@ -58,6 +58,7 @@ template {
   display: none;
 }
 a {
+  color: var(--primary-color);
   background-color: transparent;
   -webkit-text-decoration-skip: objects;
 }
@@ -634,4 +635,14 @@ footer a {
   html {
     font-size: 100%;
   }
+}
+.two-up {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+}
+.two-up > * {
+  width: 500px;
+  margin-bottom: 1em;
+  margin-right: 1em;
 }

--- a/frontend/src/components/layout.css
+++ b/frontend/src/components/layout.css
@@ -268,7 +268,6 @@ textarea {
 h2 {
   margin-left: 0;
   margin-right: 0;
-  margin-top: 0;
   padding-bottom: 0;
   padding-left: 0;
   padding-right: 0;

--- a/frontend/src/components/mapbox.css
+++ b/frontend/src/components/mapbox.css
@@ -2,6 +2,7 @@
   width: 100%;
   height: 40vh;
   margin-bottom: 2em;
+  position: relative;
 }
 
 .map-overlay {
@@ -9,13 +10,7 @@
   justify-content: center;
   align-items: center;
   font-size: 1.5rem;
-
-  padding-left: 3rem;
-  padding-right: 6rem;
-
-  background: white;
-  opacity: 0.8;
-
+  background-color: rgba(255, 255, 255, 0.8);
   position: absolute;
   width: 100%;
   height: 40vh;

--- a/frontend/src/components/voting-phones.css
+++ b/frontend/src/components/voting-phones.css
@@ -1,0 +1,23 @@
+.voting-phones {
+  border: 1px solid #000;
+}
+
+.voting-phones__headline {
+  margin-top: 0;
+  padding: 0.5em;
+  border-bottom: 1px solid #000;
+}
+
+.voting-phones__list {
+  list-style-type: none;
+  margin-right: 0.5em;
+}
+
+.voting-phones__label {
+  font-weight: bold;
+}
+
+.voting-phones__text {
+  margin-left: 2ch;
+  margin-right: 2ch;
+}

--- a/frontend/src/components/voting-phones.js
+++ b/frontend/src/components/voting-phones.js
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types"
+import React from "react"
+
+import "./voting-phones.css"
+
+const VotingPhones = () => (
+  <section className="voting-phones">
+    <h2 className="voting-phones__headline">Voting Information Helplines</h2>
+    <p className="voting-phones__text">All resources are nonpartisan, and here to help with any issues.</p>
+    <ul className="voting-phones__list">
+      <li className="voting-phones__item">
+        <span className="voting-phones__label">English</span>
+        <span> — </span>
+        <a href="tel:+18666878683">866-OUR-VOTE</a>
+      </li>
+      <li className="voting-phones__item">
+        <span className="voting-phones__label">Spanish/English</span>
+        <span> — </span>
+        <a href="tel:+18888398682">888-VE-Y-VOTA</a>
+      </li>
+      <li className="voting-phones__item">
+        <span className="voting-phones__label">Arabic/English</span>
+        <span> — </span>
+        <a href="tel:+18449255287">844-YALLA-US</a>
+      </li>
+      <li className="voting-phones__item">
+        <span className="voting-phones__label">Asian Languages/English</span>
+        <span> — </span>
+        <a href="tel:+18882748683">888-API-VOTE</a>
+      </li>
+    </ul>
+  </section>
+)
+
+VotingPhones.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  headline: PropTypes.string.isRequired,
+}
+
+export default VotingPhones

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 
 import Ctas from "../components/ctas"
 import DatesDeadlines from "../components/dates-deadlines"
+import VotingPhones from "../components/voting-phones"
 import Layout from "../components/layout"
 import Mapbox from "../components/Mapbox"
 import Polling from "../components/polling"
@@ -13,10 +14,13 @@ const IndexPage = () => {
   return (
     <Layout>
       <SEO title="Home" />
-      <DatesDeadlines
-        items={strings.datesDeadlines.items}
-        headline={strings.datesDeadlines.headline}
-      />
+      <div className="two-up">
+        <DatesDeadlines
+          items={strings.datesDeadlines.items}
+          headline={strings.datesDeadlines.headline}
+        />
+        <VotingPhones />
+      </div>
       <Polling
         items={strings.polling.items}
         headline={strings.polling.headline}

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,7 +2,6 @@ import React, { useState } from "react"
 
 import Ctas from "../components/ctas"
 import DatesDeadlines from "../components/dates-deadlines"
-import GridBox from "../components/grid-box"
 import Layout from "../components/layout"
 import Mapbox from "../components/Mapbox"
 import Polling from "../components/polling"
@@ -18,18 +17,16 @@ const IndexPage = () => {
         items={strings.datesDeadlines.items}
         headline={strings.datesDeadlines.headline}
       />
-      <GridBox>
-        <Polling
-          items={strings.polling.items}
-          headline={strings.polling.headline}
-          submit={strings.polling.submit}
-          setVoterData={setVoterData}
-        />
-        <Mapbox voterData={voterData} />
-        <Ctas items={strings.ctas} />
-      </GridBox>
-    </Layout>
-  )
+      <Polling
+        items={strings.polling.items}
+        headline={strings.polling.headline}
+        submit={strings.polling.submit}
+        setVoterData={setVoterData}
+      />
+      <Mapbox voterData={voterData} />
+      <Ctas items={strings.ctas} />
+  </Layout>
+)
 }
 
 export default IndexPage


### PR DESCRIPTION
This PR includes...

##  Remove GridBox

This is no longer needed in the current design, so remove from the output for now.

## Fix horizontal scroll bars

The map box overlay element is causing some horizontal scrollbars by being larger than the screen area.

This is because it is set to `width: 100%` *and* has `position: absolute`. Absolutely positioned elements are absolute relative to their first ancestor with `position: relative` (double relative, confusing, yes), or `body`. Since the wrapper element for the map isn't positioned relative, the overlay and the map itself calculate their width differently. Adding `position: relative` to the wrapper fixes that up.

In addition, use `rgba` instead of `opacity` here for the transparency effect on the overlay. This is because opacity effects the entire element and all it's contents - including the text - where as the rgba rule can be applied only to the background, making the definition between background and text more clear.

## Add voting phones component

Add voting information phone numbers. Also add primary color to regular links.
