### PR TITLE
Increased zoom after address input, made early voting popup appear and center by default, added early voting schedule to side bar map overlay

### DIFF
--- a/frontend/src/components/Mapbox.js
+++ b/frontend/src/components/Mapbox.js
@@ -6,34 +6,14 @@ import "./mapbox.css"
 
 const Mapbox = props => {
   const mapContainer = useRef(null)
-  // const getNeSw=(coord1,coord2)=>{
-  //   const rectangle = [
-  //     coord1,
-  //     coord2,
-  //     [coord1[0],coord2[1]],
-  //     [coord1[1],coord2[0]]
-  //   ]
-  //   let ne = coord1
-  //   let sw = coord1
-  //   let x,y
-  //   rectangle.forEach(coord=>{
-  //     if(y>ne[1]&&x>ne[0]) {
-  //       x = parseFloat(coord[0])+.01
-  //       y = parseFloat(coord[1])+.01
-  //       ne = [x,y]
-  //     }else if(y<sw[1]&&x<sw[0]){
-  //       x = parseFloat(coord[0])-.01
-  //       y = parseFloat(coord[1])-.01
-  //       sw = [x,y]
-  //     }
-  //   })
-  //   return [ne,sw]
-  // }
+  const [schedule,setSchedule] = useState(false)
   const createPopup = (earlyBool, name, addr) => {
     let vote
     if (earlyBool) vote = "Early"
     else vote = "Normal"
-    return `<h3>${vote} Voting Location</h3><p>${name}<br/>${addr}</p>`
+    return `
+    <h3>${vote} Voting Location</h3>
+    <p>${name}<br/>${addr}</p>`
   }
   useEffect(() => {
     mapboxgl.accessToken = process.env.GATSBY_MAPBOX_ACCESS_TOKEN
@@ -53,6 +33,13 @@ const Mapbox = props => {
             props.voterData.ev_site_address
           )
         )
+        earlyVotingPopup.on('open',(e)=>{
+          setSchedule(true)
+        })
+        earlyVotingPopup.on('close',(e)=>{
+          setSchedule(false)
+        })
+
         const normalVotingPopup = new mapboxgl.Popup({ offset: 25 }).setHTML(
           createPopup(
             false,
@@ -87,7 +74,62 @@ const Mapbox = props => {
           <span>Enter your address above to locate your polling sites!</span>
         </div>
       )}
-      <div ref={el => (mapContainer.current = el)} id="mapbox" />
+      <div ref={el => (mapContainer.current = el)} id="mapbox"/>
+      {schedule&&<div class="evSchedule">        
+      <h3>Early Voting Schedule</h3>
+        <table>
+          <tr>
+              <th>Day</th>
+              <th>Date</th>
+              <th>Hours</th>
+          </tr>
+          <tr>
+              <td>Saturday</td>
+              <td>October 24, 2020</td>
+              <td>10 AM to 4 PM</td>
+          </tr>
+          <tr>
+              <td>Sunday</td>
+              <td>October 25, 2020</td>
+              <td>10 AM to 4 PM</td>
+          </tr>
+          <tr>
+              <td>Monday</td>
+              <td>October 26, 2020</td>
+              <td>7 AM to 3 PM</td>
+          </tr>
+          <tr>
+              <td>Tuesday</td>
+              <td>October 27, 2020</td>
+              <td>12 PM to 8 PM</td>
+          </tr>
+          <tr>
+              <td>Wednesday</td>
+              <td>October 28, 2020</td>
+              <td>12 PM to 8 PM</td>
+          </tr>
+          <tr>
+              <td>Thursday</td>
+              <td>October 29, 2020</td>
+              <td>10 AM to 6 PM</td>
+          </tr>
+          <tr>
+              <td>Friday</td>
+              <td>October 30, 2020</td>
+              <td>7 AM to 3 PM</td>
+          </tr>
+          <tr>
+              <td>Saturday</td>
+              <td>October 31, 2020</td>
+              <td>10 AM to 4 PM</td>
+          </tr>
+          <tr>
+              <td>Sunday</td>
+              <td>November 1, 2020</td>
+              <td>10 AM to 4 PM</td>
+          </tr>
+        </table>
+      </div>}
     </div>
   )
 }

--- a/frontend/src/components/Mapbox.js
+++ b/frontend/src/components/Mapbox.js
@@ -6,11 +6,28 @@ import "./mapbox.css"
 
 const Mapbox = props => {
   const mapContainer = useRef(null)
-  // const distance=(x1,x2,y1,y2)=>{
-  //   return Math.sqrt(Math.pow(x2-x1,2)+Math.pow(y2-y1,2))
-  // }
-  // const getZoom=(distance)=>{
-  //   return 15-distance*130
+  // const getNeSw=(coord1,coord2)=>{
+  //   const rectangle = [
+  //     coord1,
+  //     coord2,
+  //     [coord1[0],coord2[1]],
+  //     [coord1[1],coord2[0]]
+  //   ]
+  //   let ne = coord1
+  //   let sw = coord1
+  //   let x,y
+  //   rectangle.forEach(coord=>{
+  //     if(y>ne[1]&&x>ne[0]) {
+  //       x = parseFloat(coord[0])+.01
+  //       y = parseFloat(coord[1])+.01
+  //       ne = [x,y]
+  //     }else if(y<sw[1]&&x<sw[0]){
+  //       x = parseFloat(coord[0])-.01
+  //       y = parseFloat(coord[1])-.01
+  //       sw = [x,y]
+  //     }
+  //   })
+  //   return [ne,sw]
   // }
   const createPopup = (earlyBool, name, addr) => {
     let vote
@@ -50,12 +67,13 @@ const Mapbox = props => {
           ])
           .setPopup(earlyVotingPopup)
           .addTo(map)
+          .togglePopup()
         const normalMarker = new mapboxgl.Marker()
           .setLngLat([props.voterData.longitude, props.voterData.latitude])
           .setPopup(normalVotingPopup)
           .addTo(map)
           map.flyTo({
-            center:[props.voterData.ev_longitude,props.voterData.ev_latitude],
+            center:[props.voterData.ev_longitude,props.voterData.ev_latitude],zoom:13,
             essential:true
           })
       }

--- a/frontend/src/components/Mapbox.js
+++ b/frontend/src/components/Mapbox.js
@@ -6,7 +6,12 @@ import "./mapbox.css"
 
 const Mapbox = props => {
   const mapContainer = useRef(null)
-
+  // const distance=(x1,x2,y1,y2)=>{
+  //   return Math.sqrt(Math.pow(x2-x1,2)+Math.pow(y2-y1,2))
+  // }
+  // const getZoom=(distance)=>{
+  //   return 15-distance*130
+  // }
   const createPopup = (earlyBool, name, addr) => {
     let vote
     if (earlyBool) vote = "Early"
@@ -19,20 +24,12 @@ const Mapbox = props => {
       container: mapContainer.current,
       style: "mapbox://styles/mapbox/streets-v11",
       center: [-73.9235, 40.7644],
-      zoom: 13.0,
+      zoom: 12.1,
     })
     map.scrollZoom.disable()
     map.on("load", () => {
-      if (!props.voterData) {
-        new mapboxgl.Popup({ offset: -25 })
-          .setLngLat([-73.9235, 40.7644])
-          .addTo(map)
-        map.addSource("nyc", {
-          type: "geojson",
-          data: "https://data.cityofnewyork.us/resource/7t3b-ywvw.geojson",
-        })
-      } else {
-        const earlyVotingPopup = new mapboxgl.Popup({ offset: 25 }).setHTML(
+      if (props.voterData) {
+        const earlyVotingPopup = new mapboxgl.Popup({}).setHTML(
           createPopup(
             true,
             props.voterData.ev_site_name,
@@ -46,17 +43,21 @@ const Mapbox = props => {
             props.voterData.site_address
           )
         )
-        new mapboxgl.Marker()
+        const evMarker = new mapboxgl.Marker()
           .setLngLat([
             props.voterData.ev_longitude,
             props.voterData.ev_latitude,
           ])
           .setPopup(earlyVotingPopup)
           .addTo(map)
-        new mapboxgl.Marker()
+        const normalMarker = new mapboxgl.Marker()
           .setLngLat([props.voterData.longitude, props.voterData.latitude])
           .setPopup(normalVotingPopup)
           .addTo(map)
+          map.flyTo({
+            center:[props.voterData.ev_longitude,props.voterData.ev_latitude],
+            essential:true
+          })
       }
     })
   }, [props.voterData])

--- a/frontend/src/components/grid-box.css
+++ b/frontend/src/components/grid-box.css
@@ -14,11 +14,6 @@
     grid-row: 1;
   }
 
-  .grid-box .schdeule {
-    grid-column: 1;
-    grid-row: 1;
-  }
-
   .grid-box .mapboxgl-map {
     grid-column: 1;
     grid-row: 2;

--- a/frontend/src/components/grid-box.css
+++ b/frontend/src/components/grid-box.css
@@ -14,6 +14,11 @@
     grid-row: 1;
   }
 
+  .grid-box .schdeule {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
   .grid-box .mapboxgl-map {
     grid-column: 1;
     grid-row: 2;

--- a/frontend/src/components/mapbox.css
+++ b/frontend/src/components/mapbox.css
@@ -2,8 +2,20 @@
   width: 100%;
   height: 40vh;
   margin-bottom: 2em;
+  position: relative;
 }
-
+.evSchedule {
+  background-color: white;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30%;
+  height: 40vh;
+  overflow: scroll;
+}
+.evSchedule table {
+  font-size: 1rem;
+}
 .map-overlay {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Increased zoom after address input, made early voting popup appear and center by default, added early voting schedule to side bar map overlay when early voting pop up is open.

Example below:
![Screen Shot 2020-10-11 at 1 33 30 PM](https://user-images.githubusercontent.com/15216567/95685670-4b9e6000-0bc7-11eb-9072-0500e3317670.png)

Another Example:
![Screen Shot 2020-10-11 at 1 33 58 PM](https://user-images.githubusercontent.com/15216567/95685683-67096b00-0bc7-11eb-9409-326541116b6c.png)

Another Example: (Early Voting popup not selected)
![Screen Shot 2020-10-11 at 1 42 49 PM](https://user-images.githubusercontent.com/15216567/95685746-bfd90380-0bc7-11eb-8fbc-32463be76333.png)
