### PR TITLE
Handle bad poll address

### DIFF
--- a/frontend/src/components/Mapbox.js
+++ b/frontend/src/components/Mapbox.js
@@ -7,6 +7,7 @@ import "./mapbox.css"
 
 const Mapbox = props => {
   const mapContainer = useRef(null)
+  const [overlay, setOverlay] = useState("Enter your address above to locate your polling sites!")
   const [schedule,setSchedule] = useState(null)
   const [evSchedule,setEVSchedule] = useState(null)
   const [content,setContent] = useState(null)
@@ -29,6 +30,11 @@ const Mapbox = props => {
     map.scrollZoom.disable()
     map.on("load", () => {
       if (props.voterData) {
+        if (props.voterData.name === "Error") {
+          setOverlay("Address not found. Please try again.")
+          setContent(null)
+          return 
+        }
         const earlyVotingPopup = new mapboxgl.Popup({}).setHTML(
           createPopup(
             true,
@@ -80,9 +86,9 @@ const Mapbox = props => {
 
   return (
     <div className="mapbox-container">
-      {props.voterData === null && (
+      {!content && (
         <div class="map-overlay">
-          <span>Enter your address above to locate your polling sites!</span>
+          <span>{overlay}</span>
         </div>
       )}
       <div ref={el => (mapContainer.current = el)} id="mapbox"/>


### PR DESCRIPTION
Previously, an incorrect address would crash the site.

For example, if a correct address is `2537 18th st`, you can test against the incorrect inputs of `2537 18th` and `25 18th st`.

Probably not the most elegant solution. The express backend is sending a 200 response with a __json body__ that says the actual original error. I am less familiar with expressJS.